### PR TITLE
Change the module to use Azure Resource Manager template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,16 @@
-resource "azurerm_servicebus_namespace" "namespace" {
-  name                = "${var.name}"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  sku                 = "standard"
+# ARM template for Service Bus namespace
+data "template_file" "namespace_template" {
+  template = "${file("${path.module}/template/namespace_template.json")}"
+}
 
-  tags {
-    source = "terraform"
+# Create Azure Service Bus namespace
+resource "azurerm_template_deployment" "namespace" {
+  template_body       = "${data.template_file.namespace_template.rendered}"
+  name                = "${var.name}"
+  deployment_mode     = "Incremental"
+  resource_group_name = "${var.resource_group_name}"
+
+  parameters = {
+    serviceBusNamespaceName = "${var.name}"
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,19 @@
-output "name" {
-  value = "${azurerm_servicebus_namespace.namespace.name}"
+# primary connection string for send and listen operations
+output "primary_send_and_listen_connection_string" {
+  value = "${azurerm_template_deployment.namespace.outputs["primaryConnectionStringForSendAndListen"]}"
+}
+
+# secondary connection string for send and listen operations
+output "secondary_send_and_listen_connection_string" {
+  value = "${azurerm_template_deployment.namespace.outputs["secondaryConnectionStringForSendAndListen"]}"
+}
+
+# primary shared access key with send and listen rights
+output "primary_send_and_listen_shared_access_key" {
+  value = "${azurerm_template_deployment.namespace.outputs["primarySharedAccessKeyForSendAndListen"]}"
+}
+
+# secondary shared access key with send and listen rights
+output "secondary_send_and_listen_shared_access_key" {
+  value = "${azurerm_template_deployment.namespace.outputs["secondarySharedAccessKeyForSendAndListen"]}"
 }

--- a/template/namespace_template.json
+++ b/template/namespace_template.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "serviceBusNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus namespace"
+      }
+    }
+  },
+  "variables": {
+    "fullRightsKeyName": "SendAndListenSharedAccessKey",
+    "sendAndListenAuthRuleResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('serviceBusNamespaceName'), variables('fullRightsKeyName'))]",
+    "sbVersion": "2017-04-01"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-04-01",
+      "name": "[parameters('serviceBusNamespaceName')]",
+      "type": "Microsoft.ServiceBus/Namespaces",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard"
+      }
+    },
+    {
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('serviceBusNamespaceName'), '/', variables('fullRightsKeyName'))]",
+      "type": "Microsoft.ServiceBus/namespaces/authorizationRules",
+      "dependsOn": [
+        "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+      ],
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "Rights": [
+          "Send",
+          "Listen"
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "primaryConnectionStringForSendAndListen": {
+      "type": "string",
+      "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString]"
+    },
+    "secondaryConnectionStringForSendAndListen": {
+      "type": "string",
+      "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).secondaryConnectionString]"
+    },
+    "primarySharedAccessKeyForSendAndListen": {
+      "type": "string",
+      "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).primaryKey]"
+    },
+    "secondarySharedAccessKeyForSendAndListen": {
+      "type": "string",
+      "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).secondaryKey]"
+    }
+  }
+}


### PR DESCRIPTION
Use an Azure Resource Manager template to create a Service Bus namespace. The out-of-the-box resource from Hashicorp doesn't support custom shared access keys and many other things.

This is just a minimal version with a small set of parameters and outputs. It will be extended as the module is used.