### PR TITLE
Set proper location for Service Bus namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,5 +12,6 @@ resource "azurerm_template_deployment" "namespace" {
 
   parameters = {
     serviceBusNamespaceName = "${var.name}"
+    location                = "${var.location}"
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,19 @@
 # primary connection string for send and listen operations
 output "primary_send_and_listen_connection_string" {
-  value = "${azurerm_template_deployment.namespace.outputs["primaryConnectionStringForSendAndListen"]}"
+  value = "${azurerm_template_deployment.namespace.outputs["primarySendAndListenConnectionString"]}"
 }
 
 # secondary connection string for send and listen operations
 output "secondary_send_and_listen_connection_string" {
-  value = "${azurerm_template_deployment.namespace.outputs["secondaryConnectionStringForSendAndListen"]}"
+  value = "${azurerm_template_deployment.namespace.outputs["secondarySendAndListenConnectionString"]}"
 }
 
 # primary shared access key with send and listen rights
 output "primary_send_and_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.namespace.outputs["primarySharedAccessKeyForSendAndListen"]}"
+  value = "${azurerm_template_deployment.namespace.outputs["primarySendAndListenSharedAccessKey"]}"
 }
 
 # secondary shared access key with send and listen rights
 output "secondary_send_and_listen_shared_access_key" {
-  value = "${azurerm_template_deployment.namespace.outputs["secondarySharedAccessKeyForSendAndListen"]}"
+  value = "${azurerm_template_deployment.namespace.outputs["secondarySendAndListenSharedAccessKey"]}"
 }

--- a/template/namespace_template.json
+++ b/template/namespace_template.json
@@ -7,6 +7,12 @@
       "metadata": {
         "description": "Name of the Service Bus namespace"
       }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location of the Azure data centre to deploy to"
+      }
     }
   },
   "variables": {
@@ -19,7 +25,7 @@
       "apiVersion": "2017-04-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/Namespaces",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "Standard"
       }
@@ -31,7 +37,7 @@
       "dependsOn": [
         "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
       ],
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "properties": {
         "Rights": [
           "Send",

--- a/template/namespace_template.json
+++ b/template/namespace_template.json
@@ -47,19 +47,19 @@
     }
   ],
   "outputs": {
-    "primaryConnectionStringForSendAndListen": {
+    "primarySendAndListenConnectionString": {
       "type": "string",
       "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString]"
     },
-    "secondaryConnectionStringForSendAndListen": {
+    "secondarySendAndListenConnectionString": {
       "type": "string",
       "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).secondaryConnectionString]"
     },
-    "primarySharedAccessKeyForSendAndListen": {
+    "primarySendAndListenSharedAccessKey": {
       "type": "string",
       "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).primaryKey]"
     },
-    "secondarySharedAccessKeyForSendAndListen": {
+    "secondarySendAndListenSharedAccessKey": {
       "type": "string",
       "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).secondaryKey]"
     }


### PR DESCRIPTION
Set proper location for Service Bus namespace (from the parameter provided). Also, make the names of connection strings and shared access keys consistent.