### PR TITLE
DTSPO-6371 - deploy private endpoint to vnet rg

### DIFF
--- a/private-endpoint.tf
+++ b/private-endpoint.tf
@@ -1,35 +1,26 @@
 locals {
-  use_default_subnet_id = var.subnet_id == "" ? true : false
+  use_default_subnet_id      = var.subnet_id == "" ? true : false
+  private_endpoint_rg_name   = var.project == "sds" ? "ss-${var.env}-network-rg" : "${var.project}-${var.env}-network-rg"
+  private_endpoint_vnet_name = var.project == "sds" ? "ss-${var.env}-vnet" : "${var.project}-${var.env}-vnet"
+}
 
-  default_subnet_ids = {
-    cft = {
-      sbox     = "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/cft-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/cft-sbox-vnet/subnets/private-endpoints"
-      preview  = "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/cft-preview-network-rg/providers/Microsoft.Network/virtualNetworks/cft-preview-vnet/subnets/private-endpoints"
-      perftest = "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/cft-perftest-network-rg/providers/Microsoft.Network/virtualNetworks/cft-perftest-vnet/subnets/private-endpoints"
-      ithc     = "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/resourceGroups/cft-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/cft-ithc-vnet/subnets/private-endpoints"
-      demo     = "/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/resourceGroups/cft-demo-network-rg/providers/Microsoft.Network/virtualNetworks/cft-demo-vnet/subnets/private-endpoints"
-      aat      = "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourceGroups/cft-aat-network-rg/providers/Microsoft.Network/virtualNetworks/cft-aat-vnet/subnets/private-endpoints"
-      prod     = "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/cft-prod-network-rg/providers/Microsoft.Network/virtualNetworks/cft-prod-vnet/subnets/private-endpoints"
-    }
-    sds = {
-      sbox = "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet/subnets/private-endpoints"
-      dev  = "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet/subnets/private-endpoints"
-      demo = "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/ss-demo-network-rg/providers/Microsoft.Network/virtualNetworks/ss-demo-vnet/subnets/private-endpoints"
-      test = "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet/subnets/private-endpoints"
-      ithc = "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet/subnets/private-endpoints"
-      stg  = "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet/subnets/private-endpoints"
-      prod = "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/ss-prod-network-rg/providers/Microsoft.Network/virtualNetworks/ss-prod-vnet/subnets/private-endpoints"
-    }
-  }
+data "azurerm_subnet" "private-endpoints" {
+  count    = var.enable_private_endpoint && local.use_default_subnet_id ? 1 : 0
+  provider = azurerm.private-endpoint-subnet
+
+  resource_group_name  = local.private_endpoint_rg_name
+  virtual_network_name = local.private_endpoint_vnet_name
+  name                 = "private-endpoints"
 }
 
 resource "azurerm_private_endpoint" "this" {
-  count = var.enable_private_endpoint ? 1 : 0
+  count    = var.enable_private_endpoint ? 1 : 0
+  provider = azurerm.private-endpoint-subnet
 
   name                = "${var.name}-endpoint"
   location            = var.location
-  resource_group_name = var.resource_group_name
-  subnet_id           = local.use_default_subnet_id ? local.default_subnet_ids[var.project][var.env] : var.subnet_id
+  resource_group_name = local.private_endpoint_rg_name
+  subnet_id           = local.use_default_subnet_id ? data.azurerm_subnet.private-endpoints[0].id : var.subnet_id
 
   private_service_connection {
     name                           = "${var.name}-endpoint-namespace"

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,6 @@
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint-subnet"
+  subscription_id            = var.private_endpoint_subscription_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "enable_private_endpoint" {
   description = "Enable Private endpoint? Only available with the Premium SKU, if set to true a Premium type Service Bus Namespace will be deployed automatically"
 }
 
+variable "private_endpoint_subscription_id" {
+  default     = ""
+  description = "Subscription ID of the subnet that the private endpoint will be created in. Only needed when creating a Service Bus with a Private Endpoint enabled and when the Subscription differs between the Service Bus and the target subnet."
+}
+
 variable "subnet_id" {
   default     = ""
   description = "Subnet ID to attach private endpoint to - overrides the default subnet id"


### PR DESCRIPTION
### Change description ###
Changed the resource group that the private endpoint is deployed to. They will now be deployed to the same resource group that the target subnet is in. 

Tested deploying a standard service bus on this branch then moving to master, there were 0 changes to do with service bus.

[Jenkins Build](https://sds-sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_Platform/job/sds-toffee-shared-infrastructure/job/DTSPO-6371_test_new_sb_branch/21/console)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
