### PR TITLE
Fix public access when using private endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,6 @@ locals {
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
-  enable_public_access         = var.enable_private_endpoint == true ? false : true
-  default_action               = var.enable_private_endpoint == true ? "Deny" : "Allow"
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
+  enable_public_access         = var.enable_private_endpoint == true ? false : true
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
@@ -17,7 +18,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {
       default_action = "Allow"
-      public_network_access_enabled = var.enable_public_access
+      public_network_access_enabled = local.enable_public_access
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -15,12 +15,12 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                         = var.common_tags
   capacity                     = local.capacity
   premium_messaging_partitions = local.premium_messaging_partitions
-  public_network_access_enabled = local.enable_public_access
+  public_network_access_enabled = var.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {
       default_action = "Allow"
-      public_network_access_enabled = local.enable_public_access
+      public_network_access_enabled = var.enable_public_access
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
   enable_public_access         = var.enable_private_endpoint == true ? false : true
+  default_action               = var.enable_private_endpoint == true ? "Deny" : "Allow"
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
@@ -15,7 +16,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   capacity                     = local.capacity
   premium_messaging_partitions = local.premium_messaging_partitions
   network_rule_set {
-      default_action = "Allow"
+      default_action = local.default_action
       public_network_access_enabled = local.enable_public_access
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,18 +6,18 @@ locals {
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
-  name                         = var.name
-  location                     = var.location
-  resource_group_name          = var.resource_group_name
-  sku                          = local.sku
-  tags                         = var.common_tags
-  capacity                     = local.capacity
-  premium_messaging_partitions = local.premium_messaging_partitions
+  name                          = var.name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  sku                           = local.sku
+  tags                          = var.common_tags
+  capacity                      = local.capacity
+  premium_messaging_partitions  = local.premium_messaging_partitions
   public_network_access_enabled = var.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {
-      default_action = "Allow"
+      default_action                = "Allow"
       public_network_access_enabled = var.enable_public_access
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -14,12 +14,9 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                         = var.common_tags
   capacity                     = local.capacity
   premium_messaging_partitions = local.premium_messaging_partitions
-  dynamic "network_rule_set" {
-    for_each = var.enable_private_endpoint ? [1] : []
-    content {
+  network_rule_set {
       default_action = "Allow"
       public_network_access_enabled = local.enable_public_access
-    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,13 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                         = var.common_tags
   capacity                     = local.capacity
   premium_messaging_partitions = local.premium_messaging_partitions
-  network_rule_set {
-      default_action = local.default_action
+  public_network_access_enabled = local.enable_public_access
+  dynamic "network_rule_set" {
+    for_each = var.enable_private_endpoint ? [1] : []
+    content {
+      default_action = "Allow"
       public_network_access_enabled = local.enable_public_access
+    }
   }
 }
 


### PR DESCRIPTION
### Change description

Raised by the idam team.
Public access is being enabled when private endpoint is in use because `public_network_access_enabled` must be defined twice
See https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace#public_network_access_enabled-1
and https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace#public_network_access_enabled-2

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
