### PR TITLE
Use a local instead for enable_public_access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 locals {
-  auth_rule_name               = "SendAndListenSharedAccessKey"
-  sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
-  capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
-  premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
+  auth_rule_name                = "SendAndListenSharedAccessKey"
+  sku                           = var.enable_private_endpoint == true ? "Premium" : var.sku
+  enable_public_access          = var.enable_private_endpoint == true ? false : var.enable_public_access 
+  capacity                      = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
+  premium_messaging_partitions  = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
@@ -13,7 +14,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = var.enable_public_access
+  public_network_access_enabled = local.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {


### PR DESCRIPTION
### Change description

Raised by the idam team that there is the chance that `enable_public_access` and `enable_private_endpoint` could both be set to true
Updating to a local so this is no longer possible

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
