### PR TITLE
Make public access default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module "servicebus_namespace" {
 | <a name="input_capacity"></a> [capacity](#input\_capacity) | Specifies the capacity. Defaults to 1 when using Premium SKU. | `number` | `0` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | n/a | `map(string)` | n/a | yes |
 | <a name="input_enable_private_endpoint"></a> [enable\_private\_endpoint](#input\_enable\_private\_endpoint) | Enable Private endpoint? Only available with the Premium SKU, if set to true a Premium type Service Bus Namespace will be deployed automatically | `bool` | `false` | no |
-| <a name="input_enable_public_access"></a> [enable\_public\_access](#input\_enable\_public\_access) | Enable public access (should only be enabled for a migration when using the Premium SKU and a private endpoint connection) | `bool` | `false` | no |
+| <a name="input_enable_public_access"></a> [enable\_public\_access](#input\_enable\_public\_access) | Enable public access (should only be enabled for a migration when using the Premium SKU and a private endpoint connection) | `bool` | `true` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | `"UK South"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Unique Azure Service Bus namespace | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   auth_rule_name               = "SendAndListenSharedAccessKey"
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
-  enable_private_access        = var.enable_private_endpoint == true && var.enable_private_access == true ? true : var.enable_private_access
+  enable_private_access        = (var.enable_private_endpoint == true && var.enable_private_access == true) ? true : var.enable_private_access
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 locals {
-  auth_rule_name                = "SendAndListenSharedAccessKey"
-  sku                           = var.enable_private_endpoint == true ? "Premium" : var.sku
-  enable_public_access          = var.enable_private_endpoint == true ? false : var.enable_public_access 
-  capacity                      = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
-  premium_messaging_partitions  = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
+  auth_rule_name               = "SendAndListenSharedAccessKey"
+  sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
+  enable_public_access         = var.enable_private_endpoint == true && var.enable_public_access == false ? false : var.enable_public_access
+  capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
+  premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }
 
 resource "azurerm_servicebus_namespace" "servicebus_namespace" {
@@ -14,7 +14,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = var.enable_public_access
+  public_network_access_enabled = local.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   auth_rule_name               = "SendAndListenSharedAccessKey"
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
-  enable_private_access        = var.enable_private_endpoint == true && var.enable_private_access == true ? true : var.enable_public_access
+  enable_public_access         = var.enable_private_endpoint == true && var.enable_public_access == false ? false : var.enable_public_access
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }
@@ -14,12 +14,12 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = local.enable_private_access
+  public_network_access_enabled = local.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {
       default_action                = "Allow"
-      public_network_access_enabled = var.enable_public_access
+      public_network_access_enabled = local.enable_public_access
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = local.enable_public_access
+  public_network_access_enabled = var.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   auth_rule_name               = "SendAndListenSharedAccessKey"
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
-  enable_public_access         = var.enable_private_endpoint == true && var.enable_public_access == false ? false : var.enable_public_access
+  enable_private_access        = var.enable_private_endpoint == true && var.enable_private_access == true ? true : var.enable_private_access
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }
@@ -14,7 +14,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = local.enable_public_access
+  public_network_access_enabled = local.enable_private_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   auth_rule_name               = "SendAndListenSharedAccessKey"
   sku                          = var.enable_private_endpoint == true ? "Premium" : var.sku
-  enable_private_access        = (var.enable_private_endpoint == true && var.enable_private_access == true) ? true : var.enable_private_access
+  enable_private_access        = var.enable_private_endpoint == true && var.enable_private_access == true ? true : var.enable_public_access
   capacity                     = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.capacity <= 0 ? 1 : var.capacity
   premium_messaging_partitions = local.sku != "Premium" ? 0 : local.sku == "Premium" && var.premium_messaging_partitions <= 0 ? 1 : var.premium_messaging_partitions
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_servicebus_namespace" "servicebus_namespace" {
   tags                          = var.common_tags
   capacity                      = local.capacity
   premium_messaging_partitions  = local.premium_messaging_partitions
-  public_network_access_enabled = var.enable_public_access
+  public_network_access_enabled = local.enable_public_access
   dynamic "network_rule_set" {
     for_each = var.enable_private_endpoint ? [1] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -40,8 +40,15 @@ variable "capacity" {
 
 variable "enable_public_access" {
   type        = bool
-  default     = true
+  default     = false
   description = "Enable public access (should only be enabled for a migration when using the Premium SKU and a private endpoint connection)"
+}
+
+# enable_private_access is separate to enable_public_access to ensure backwards compatibility with existing module calls.
+variable "enable_private_access" {
+  type        = bool
+  default     = false
+  description = "Disable public access in favour of private endpoint only"
 }
 
 variable "enable_private_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "capacity" {
 
 variable "enable_public_access" {
   type        = bool
-  default     = false
+  default     = true
   description = "Enable public access (should only be enabled for a migration when using the Premium SKU and a private endpoint connection)"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,13 +44,6 @@ variable "enable_public_access" {
   description = "Enable public access (should only be enabled for a migration when using the Premium SKU and a private endpoint connection)"
 }
 
-# enable_private_access is separate to enable_public_access to ensure backwards compatibility with existing module calls.
-variable "enable_private_access" {
-  type        = bool
-  default     = false
-  description = "Disable public access in favour of private endpoint only"
-}
-
 variable "enable_private_endpoint" {
   default     = false
   description = "Enable Private endpoint? Only available with the Premium SKU, if set to true a Premium type Service Bus Namespace will be deployed automatically"


### PR DESCRIPTION
### Change description

Fixing the issue for idam that ensures they can make their namespace private whilst not affecting existing service bus namesapces.
It seems this bug in the config has meant most namespaces are public and existing network expects that so we don't want to enforce this change on teams unless they explicitly ask for it
Updating `enable_public_access` to default to `true` so teams have to specify it as `false` explicitly
This aligns with how our service buses are currently configured so it doesn't change any settings.

See tests completed:

https://github.com/hmcts/civil-sdt/pull/859
https://github.com/hmcts/reform-scan-shared-infra/pull/161
https://github.com/hmcts/idam-shared-infrastructure/pull/185

The above PRs show no changes to service bus namespaces.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
